### PR TITLE
[#32] 토큰 없이 /todo 페이지에 접속하는 경우 /signin 경로로 리다이렉트

### DIFF
--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -33,6 +33,8 @@ function Join() {
       navigate(ROUTE_TODO);
       return;
     }
+    navigate(ROUTE_SIGNIN);
+    return;
   };
 
   return (


### PR DESCRIPTION
fixes #32 